### PR TITLE
POW-524: Add a maximum size limit to all headers combined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ message("--+ Toolchain information:")
 message("  +--> C Compiler: ${CMAKE_C_COMPILER}")
 message("  +--> CXX Compiler: ${CMAKE_CXX_COMPILER}")
 message("  +--> Environment CFLAGS: $ENV{CFLAGS}")
+
+enable_hardening_flags()
 ## END OOKLA CHANGES ##
 
 # Put the libaries and binaries that get built into directories at the

--- a/Foundation/src/Thread_POSIX.cpp
+++ b/Foundation/src/Thread_POSIX.cpp
@@ -23,6 +23,7 @@
 #if POCO_OS == POCO_OS_FREE_BSD
 #    include <pthread_np.h>
 #    include <osreldate.h>
+#    include <sys/thr.h>
 #endif
 
 #if defined(__sun) && defined(__SVR4)
@@ -285,7 +286,11 @@ long ThreadImpl::currentOsTidImpl()
 #elif POCO_OS == POCO_OS_MAC_OS_X
     return ::pthread_mach_thread_np(::pthread_self());
 #elif POCO_OS == POCO_OS_FREE_BSD
-    return ::pthread_getthreadid_np();
+    long id;
+    if(thr_self(&id) < 0) {
+        return 0;
+    }
+    return id;
 #else
     pthread_t type;
     return ::pthread_self();

--- a/Net/include/Poco/Net/MessageHeader.h
+++ b/Net/include/Poco/Net/MessageHeader.h
@@ -169,6 +169,8 @@ public:
 	static std::string decodeWord(const std::string& text, const std::string& charset = "UTF-8");
 	        /// Decode RFC2047 string.
 
+            // Set maximum number of bytes allows for all headers (first line excluded). Defaults to 65KiB.
+    static void setTotalHeaderLimit(int max);
 
 private:
 	enum Limits
@@ -176,12 +178,15 @@ private:
 	{
 		DFL_NAME_LENGTH_LIMIT  = 256,
 		DFL_VALUE_LENGTH_LIMIT = 8192,
-		DFL_FIELD_LIMIT = 100
-	};
+		DFL_FIELD_LIMIT = 100,
+        DFL_HEADER_LIMIT = 65536 // OOKLA MODIFICATION
+    };
 
 	int _fieldLimit;
 	int _nameLengthLimit;
 	int _valueLengthLimit;
+
+    static int _totalHeaderLimit; // OOKLA MODIFICATION
 
 };
 


### PR DESCRIPTION
The header parsing code is.. not very clean. This adds a limit to total bytes that's configurable.

Also note that the hardening flags from the latest SSS are included.